### PR TITLE
Allow custom attributes in top level

### DIFF
--- a/examples/dirtree.rkt
+++ b/examples/dirtree.rkt
@@ -24,7 +24,7 @@
   (exit 0))
 
 (define (dirtree path depth)
-  (make-digraph (dirtree-defs path depth) #:ortho #f))
+  (make-digraph (dirtree-defs path depth) #:splines "true"))
 
 (define (dirtree-defs path depth)
   (let*-values

--- a/lib/erdiagram.rkt
+++ b/lib/erdiagram.rkt
@@ -15,7 +15,7 @@
   (define digraph
     (make-digraph
      (append vertices edges)
-     #:ortho #t))
+     #:splines "ortho"))
   (digraph->pict digraph))
 
 (define (table->vertex table)

--- a/main.rkt
+++ b/main.rkt
@@ -38,50 +38,50 @@
   ;; Any code in this `test` submodule runs when this file is run using DrRacket
   ;; or with `raco test`. The code here does not run when this file is
   ;; required by another module.
-(define examples
-  `(
+ (define examples
+   `(
     ;; graph 1
-    (["A" #:shape "diamond"]
-     ["B" #:shape "box"]
-     ["C" #:shape "circle"]
-     [("A" "B") #:style "dashed" #:color "grey"]
-     [("A" "C") #:color "black:invis:black"]
-     [("A" "D") #:penwidth "5" #:arrowhead "none"])
+     (["A" #:shape "diamond"]
+      ["B" #:shape "box"]
+      ["C" #:shape "circle"]
+      [("A" "B") #:style "dashed" #:color "grey"]
+      [("A" "C") #:color "black:invis:black"]
+      [("A" "D") #:penwidth "5" #:arrowhead "none"])
     ;; graph 2
-    ([subgraph "process #1"
-               #:style "filled"
-               #:color "lightgrey"
-               ("a0 -> a1 -> a2 -> a3")]
-     [subgraph "process #2"
-               #:color "blue"
-               ("b0 -> b1 -> b2 -> b3")]
-     "start -> a0"
-     "start -> b0"
-     "a1 -> b3"
-     "b2 -> a3"
-     "a3 -> a0"
-     "a3 -> end"
-     "b3 -> end"
-     ["start" #:shape "Mdiamond"]
-     ["end" #:shape "Msquare"])
+     ([subgraph "process #1"
+                #:style "filled"
+                #:color "lightgrey"
+                ("a0 -> a1 -> a2 -> a3")]
+      [subgraph "process #2"
+                #:color "blue"
+                ("b0 -> b1 -> b2 -> b3")]
+      "start -> a0"
+      "start -> b0"
+      "a1 -> b3"
+      "b2 -> a3"
+      "a3 -> a0"
+      "a3 -> end"
+      "b3 -> end"
+      ["start" #:shape "Mdiamond"]
+      ["end" #:shape "Msquare"])
     ;;
-    (["a" #:shape "diamond" #:fillcolor "lightgray" #:style "filled"]
-     ["b" #:shape ,(cloud 60 30) #:label "c"]
-     ["c" #:shape ,(standard-fish 100 50 #:open-mouth #t #:color "Chartreuse")
-          #:label ""]
-     "d"
-     "a -> b -> c"
-     "a -> d -> c"
-     (subgraph "stdout" #:style "filled" #:fillcolor "cyan"
-               (["f" #:shape ,(file-icon 50 60 "bisque")]
-                "g"
-                "f -> g"))
-     "d -> g")))
+     (["a" #:shape "diamond" #:fillcolor "lightgray" #:style "filled"]
+      ["b" #:shape ,(cloud 60 30) #:label "c"]
+      ["c" #:shape ,(standard-fish 100 50 #:open-mouth #t #:color "Chartreuse")
+           #:label ""]
+      "d"
+      "a -> b -> c"
+      "a -> d -> c"
+      (subgraph "stdout" #:style "filled" #:fillcolor "cyan"
+                (["f" #:shape ,(file-icon 50 60 "bisque")]
+                 "g"
+                 "f -> g"))
+      "d -> g")))
 
-(for/list ([d examples])
-  (digraph->pict (make-digraph d)))
+ (for/list ([d examples])
+   (digraph->pict (make-digraph d))))
   
-  )
+  
 
 (module+ main
   ;; (Optional) main submodule. Put code here if you need it to be executed when


### PR DESCRIPTION
* Allow custom attributes in top level
  * #:ortho #t -> #:splines "ortho"
* Node shape is now `none`. This allows the android lifecycle example to work with different spline types

Related issue: #10 